### PR TITLE
fix build issue in ROS Melodic (cannot convert boost::shared_ptr to b…

### DIFF
--- a/variant_topic_tools/src/DataType.cpp
+++ b/variant_topic_tools/src/DataType.cpp
@@ -97,21 +97,21 @@ size_t DataType::getSize() const {
 
 bool DataType::isArray() const {
   if (impl)
-    return boost::dynamic_pointer_cast<ArrayDataType::Impl>(*impl);
+    return boost::dynamic_pointer_cast<ArrayDataType::Impl>(*impl) != nullptr;
   else
     return false;
 }
 
 bool DataType::isBuiltin() const {
   if (impl)
-    return boost::dynamic_pointer_cast<BuiltinDataType::Impl>(*impl);
+    return boost::dynamic_pointer_cast<BuiltinDataType::Impl>(*impl) != nullptr;
   else
     return false;
 }
 
 bool DataType::isMessage() const {
   if (impl)
-    return boost::dynamic_pointer_cast<MessageDataType::Impl>(*impl);
+    return boost::dynamic_pointer_cast<MessageDataType::Impl>(*impl) != nullptr;
   else
     return false;
 }
@@ -131,7 +131,7 @@ bool DataType::isSimple() const {
 }
 
 bool DataType::isValid() const {
-  return impl;
+  return impl != nullptr;
 }
 
 bool DataType::hasTypeInfo() const {

--- a/variant_topic_tools/src/MessageMember.cpp
+++ b/variant_topic_tools/src/MessageMember.cpp
@@ -68,20 +68,20 @@ const DataType& MessageMember::getType() const {
 
 bool MessageMember::isVariable() const {
   if (impl)
-    return boost::dynamic_pointer_cast<MessageVariable::Impl>(impl);
+    return boost::dynamic_pointer_cast<MessageVariable::Impl>(impl) != nullptr;
   else
     return false;
 }
 
 bool MessageMember::isConstant() const {
   if (impl)
-    return boost::dynamic_pointer_cast<MessageConstant::Impl>(impl);
+    return boost::dynamic_pointer_cast<MessageConstant::Impl>(impl) != nullptr;
   else
     return false;
 }
 
 bool MessageMember::isValid() const {
-  return impl;
+  return impl != nullptr;
 }
 
 /*****************************************************************************/

--- a/variant_topic_tools/src/Serializer.cpp
+++ b/variant_topic_tools/src/Serializer.cpp
@@ -59,7 +59,7 @@ size_t Serializer::getSerializedLength(const Variant& value) const {
 }
 
 bool Serializer::isValid() const {
-  return impl;
+  return impl != nullptr;
 }
 
 /*****************************************************************************/

--- a/variant_topic_tools/src/Variant.cpp
+++ b/variant_topic_tools/src/Variant.cpp
@@ -66,28 +66,28 @@ bool Variant::hasType() const {
 
 bool Variant::isArray() const {
   if (value)
-    return boost::dynamic_pointer_cast<ArrayVariant::Value>(value);
+    return boost::dynamic_pointer_cast<ArrayVariant::Value>(value) != nullptr;
   else
     return false;
 }
 
 bool Variant::isBuiltin() const {
   if (value)
-    return boost::dynamic_pointer_cast<BuiltinVariant::Value>(value);
+    return boost::dynamic_pointer_cast<BuiltinVariant::Value>(value) != nullptr;
   else
     return false;
 }
 
 bool Variant::isCollection() const {
   if (value)
-    return boost::dynamic_pointer_cast<CollectionVariant::Value>(value);
+    return boost::dynamic_pointer_cast<CollectionVariant::Value>(value) != nullptr;
   else
     return false;
 }
 
 bool Variant::isMessage() const {
   if (value)
-    return boost::dynamic_pointer_cast<MessageVariant::Value>(value);
+    return boost::dynamic_pointer_cast<MessageVariant::Value>(value) != nullptr;
   else
     return false;
 }


### PR DESCRIPTION
 Fix build issue in ROS Melodic:
```
Cannot convert boost::shared_ptr<...> to bool
```
`boost::shared_ptr` in ROS Melodic is explicit.
```
template<class T> class shared_ptr {
public:
    ...
    explicit operator bool() const noexcept;
    ...
}
```
Using `boost::shared_ptr<...> != nullptr` instead.